### PR TITLE
Fix invalid ID selector

### DIFF
--- a/lib/web/js/look/look.metrics.js
+++ b/lib/web/js/look/look.metrics.js
@@ -47,9 +47,9 @@ var Look = (function () {
 				that.Metrics.data[metric.source][metric.scope] = {};
 
 				var scope = $('<section id="' + scopeSectionId  + '"><div class="page-header"><h2>' + metric.scope + '</h2></div><div class="row"></div></section>');
-				$('#' + sourceTabId).append(scope);
+				$('#' + sourceTabId.replace('.', '\\.')).append(scope);
 				
-				$('#' + sourceTabId + ' section').sortElements(function (element1, element2) {
+				$('#' + sourceTabId.replace('.', '\\.') + ' section').sortElements(function (element1, element2) {
 					var
 						name1 = $(element1).find('h2').html().toLowerCase(),
 						name2 = $(element2).find('h2').html().toLowerCase();
@@ -62,9 +62,9 @@ var Look = (function () {
 			}
 
 			if (!that.Metrics.data[metric.source][metric.scope][metric.name]) {
-				$('#' + scopeSectionId + ' .row').append('<div class="span6"><h4>' + metric.name  + '</h4><div class="plot" id="' + plotId + '" style="width: 100%; height: 200px;"></div></div>');
+				$('#' + scopeSectionId.replace('.', '\\.') + ' .row').append('<div class="span6"><h4>' + metric.name  + '</h4><div class="plot" id="' + plotId + '" style="width: 100%; height: 200px;"></div></div>');
 
-				$('#' + scopeSectionId + ' .row > div').sortElements(function (element1, element2) {
+				$('#' + scopeSectionId.replace('.', '\\.') + ' .row > div').sortElements(function (element1, element2) {
 					var
 						name1 = $(element1).find('h4').html().toLowerCase(),
 						name2 = $(element2).find('h4').html().toLowerCase();
@@ -72,7 +72,7 @@ var Look = (function () {
 					return name1 > name2 ? 1 : -1;
 				});
 
-				that.Metrics.data[metric.source][metric.scope][metric.name] = { label: label, scope: metric.scope, name: metric.name, series: [], plot: $('#' + plotId) };
+				that.Metrics.data[metric.source][metric.scope][metric.name] = { label: label, scope: metric.scope, name: metric.name, series: [], plot: $('#' + plotId.replace('.', '\\.')) };
 			}
 
 			that.Metrics.data[metric.source][metric.scope][metric.name].series.push(metric);


### PR DESCRIPTION
If source has `.`(for example, My.local), jQuery ID selector doesn't work. 
