### PR TITLE
Явно обозначил процесс в котором поднимается модуль

### DIFF
--- a/lib/look.js
+++ b/lib/look.js
@@ -12,8 +12,8 @@ agentio.createClient = function () {
 };
 
 module.exports.start = function (port, host) {
-	if (cluster.isMaster) {
-		var observer = child_process.fork(__dirname + '/observer', [ port, host ]);
+	if (!process.env.isObserver) {
+		var observer = child_process.fork(__dirname + '/observer', [ port, host ], {env: {isObserver: true}});
 
 		observer.on('message', function (data) {
 			if (data.cmd === 'init') {


### PR DESCRIPTION
Для того чтобы использовать эту зависимость было возможно в процессах уже порожденных, например мы отлаживаем дочку кластера, не стоит использовать флаг isMaster.
